### PR TITLE
Export

### DIFF
--- a/channelworm/ion_channel/exporter.py
+++ b/channelworm/ion_channel/exporter.py
@@ -1,4 +1,6 @@
-import adapters
+import rdflib
+from adapters import Adapter
+from django.db.models import Model
 
 class Exporter(object):
     """
@@ -7,23 +9,50 @@ class Exporter(object):
     """
     def __init__(self, *args):
         self.data = []
+        self.graph = rdflib.Graph()
+        self.exported = False
         if args:
             self.load(*args)
 
     def load(self, *args):
         """
-        Load data into the Exporter.
+        Load new ChannelWorm data into the Exporter.
         """
         for item in args:
-            print(item)
+            if not isinstance(item, Model):
+                raise TypeError(
+                    'Item {} is not instance of {}.'
+                    .format(item, type(Model))
+                )
             self.data.append(item)
 
-    def export(self, filename):
+    def parse(self, source=None, format='n3'):
+        """
+        Load data from the previous graph into the Exporter.
+        """
+        if not source:
+            raise TypeError('No data source specified.')
+        self.graph.parse(
+            source=source,
+            format=format
+        )
+
+    def export(self, filename=None, format='n3'):
         """
         Export the ChannelWorm data to a flat file that can be
         consumed by PyOpenWorm.
         """
-        for item in self.data:
-            # call adapter on each item
-            # do something with resulting PyOW objects
-            pass # (for now)
+        if not self.exported:
+            for item in self.data:
+                item_adapter = Adapter.create(item)
+                pyow_object = item_adapter.get_pow()
+                trips = pyow_object.triples()
+                for triple in trips:
+                    self.graph.add(trip)
+            self.exported = True
+
+        self.graph.serialize(
+            destination=filename,
+            format=format
+        )
+

--- a/channelworm/ion_channel/exporter.py
+++ b/channelworm/ion_channel/exporter.py
@@ -2,10 +2,26 @@ import rdflib
 from adapters import Adapter
 from django.db.models import Model
 
+
 class Exporter(object):
     """
-    An Exporter can be loaded with data, and then export 
-    that data to a flat file.
+    An Exporter that can be loaded with data, and then export 
+    that data as a serialized RDF graph.
+
+    Parameters given when initializing an Exporter are passed to
+    `load()`.
+
+    Example usage ::
+        
+        >>> ex = Exporter(obj1, obj2, obj3)
+        >>> ex.load(obj4)
+        >>> ex.parse('my_old_graph.n3')
+        >>> ex.export('my_new_graph.n3')
+    
+    In the usage example above, 'my_new_graph.n3' is a serialized
+    RDF graph combining the old graph and RDF representations of
+    PyOpenWorm objects corresponding to ChannelWorm objects obj1
+    through obj4.
     """
     def __init__(self, *args):
         self.data = []
@@ -17,6 +33,8 @@ class Exporter(object):
     def load(self, *args):
         """
         Load new ChannelWorm data into the Exporter.
+
+        Takes ChannelWorm Django data objects.
         """
         for item in args:
             if not isinstance(item, Model):
@@ -28,7 +46,15 @@ class Exporter(object):
 
     def parse(self, source=None, format='n3'):
         """
-        Load data from the previous graph into the Exporter.
+        Load data from a previous graph into the Exporter.
+
+        Parameters
+        ----------
+        source : string 
+            Path to the previous graph.
+        format : string (optional)
+            Format of the previous graph.
+            See `rdflib.graph.Graph.parse.format` for possible values.
         """
         if not source:
             raise TypeError('No data source specified.')
@@ -41,6 +67,14 @@ class Exporter(object):
         """
         Export the ChannelWorm data to a flat file that can be
         consumed by PyOpenWorm.
+
+        Parameters
+        ----------
+        filename : string
+            Path to export the serialized graph to.
+        format : string (optional)
+            Format to serialize in.
+            See `rdflib.graph.Graph.parse.format` for possible values.
         """
         if not self.exported:
             for item in self.data:
@@ -48,7 +82,7 @@ class Exporter(object):
                 pyow_object = item_adapter.get_pow()
                 trips = pyow_object.triples()
                 for triple in trips:
-                    self.graph.add(trip)
+                    self.graph.add(triple)
             self.exported = True
 
         self.graph.serialize(

--- a/channelworm/ion_channel/exporter.py
+++ b/channelworm/ion_channel/exporter.py
@@ -1,0 +1,29 @@
+import adapters
+
+class Exporter(object):
+    """
+    An Exporter can be loaded with data, and then export 
+    that data to a flat file.
+    """
+    def __init__(self, *args):
+        self.data = []
+        if args:
+            self.load(*args)
+
+    def load(self, *args):
+        """
+        Load data into the Exporter.
+        """
+        for item in args:
+            print(item)
+            self.data.append(item)
+
+    def export(self, filename):
+        """
+        Export the ChannelWorm data to a flat file that can be
+        consumed by PyOpenWorm.
+        """
+        for item in self.data:
+            # call adapter on each item
+            # do something with resulting PyOW objects
+            pass # (for now)

--- a/tests/adapter_test.py
+++ b/tests/adapter_test.py
@@ -1,236 +1,158 @@
-from django.test import TestCase
-from django.utils import timezone
-from ion_channel.adapters import Adapter
 import PyOpenWorm, pytest, unittest, random
-from ion_channel.models import *
+from django.test import TestCase
+from ion_channel.adapters import Adapter
+from ion_channel.models import (
+    IonChannel, Reference, Experiment, PatchClamp, User
+)
 
+pytestmark = [pytest.mark.django_db]
 
-class AdapterTestCase(TestCase):
-    def get_user(self):
-        """
-        Fixture for getting a User object.
-        If we already created one, we can just get it
-        rather than making another.
-        """
-        if not hasattr(self, 'user'):
-            self.user = User.objects.create(username='user')
+def test_create_reference(data_pool):
+    """Test that we can make a Reference object manually."""
+    assert isinstance(data_pool.get_reference(), Reference)
 
-        return self.user
+def test_adapt_reference(data_pool):
+    """Test that we can map a Reference object to a PyOpenWorm
+    Experiment object."""
+    r = data_pool.get_reference()
 
-    def get_reference(self):
-        """
-        Fixture for getting a Reference object.
-        """
-        if not hasattr(self, 'reference'):
-            self.reference = Reference.objects.create(
-                PMID='000000',
-                authors='Einstein et al.',
-                create_date=timezone.now(),
-                doi='123abc',
-                title='Hello Worm',
-                url='http://example.co.uk',
-                username=self.get_user(),
-                year=2001,
-            )
+    reference_adapter = Adapter.create(r)
 
-        return self.reference
+    experiment = reference_adapter.get_pow()
+    reference = reference_adapter.get_cw()
 
-    def get_experiment(self):
-        """
-        Fixture for getting an Experiment object.
-        """
-        if not hasattr(self, 'experiment'):
-            self.experiment = Experiment.objects.create(
-                reference=self.get_reference(),
-                username=self.get_user(),
-                create_date=timezone.now(),
-            )
+    PyOpenWorm.connect()
 
-        return self.experiment
+    pyow_dict = {
+        'authors': experiment.author(),
+        'doi': experiment.doi(),
+        'pmid': experiment.pmid(),
+        'title': experiment.title(),
+        'url': experiment.uri(),
+        'year': experiment.year(),
+    }
 
-    def get_ion_channel(self):
-        """
-        Fixture for getting an IonChannel object.
-        """
-        if not hasattr(self, 'ion_channel'):
-            self.ion_channel = IonChannel.objects.create(
-                channel_name='CNN',
-                description='Yup, it is a channel.',
-                description_evidences='0000000, 000001',
-                gene_name='Gene Clark',
-                gene_WB_ID='Wbbt:123456',
-                gene_class='Working Class',
-                proteins='BRD-5, isoform a; BRD-5, isoform b',
-                expression_pattern='Have you seen the Silver Raven?',
-                expression_evidences='000000, 000002',
-            )
+    cw_dict = {
+        'authors': set([reference.authors]),
+        'doi': reference.doi,
+        'pmid': reference.PMID,
+        'title': reference.title,
+        'url': set([reference.url]),
+        'year': reference.year
+    }
 
-        return self.ion_channel
+    PyOpenWorm.disconnect()
 
-    def get_patch_clamp(self):
-        """
-        Fixture for getting a PatchClamp object.
-        """
-        if not hasattr(self, 'patch_clamp'):
-            self.patch_clamp = PatchClamp.objects.create(
-                deltat=100,
-                duration=200,
-                end_time=200,
-                experiment=self.get_experiment(),
-                ion_channel=self.get_ion_channel(),
-                protocol_end=200,
-                protocol_start=0,
-                protocol_step=100,
-                start_time=0,
-            )
+    assert pyow_dict == cw_dict
 
-        return self.patch_clamp
+def test_create_PatchClamp(data_pool):
+    """Test that we can create a PatchClamp object manually."""
+    pc = data_pool.get_patch_clamp()
+    assert isinstance(pc, PatchClamp)
 
-    def test_create_reference(self):
-        """Test that we can make a Reference object manually."""
-        assert isinstance(self.get_reference(), Reference)
+def test_adapt_PatchClamp(data_pool):
+    """
+    Test that we can map a PatchClamp object to a PyOpenWorm
+    PatchClamp object.
+    """
+    pc = data_pool.get_patch_clamp()
 
-    def test_adapt_reference(self):
-        """Test that we can map a Reference object to a PyOpenWorm
-        Experiment object."""
-        r = self.get_reference()
+    pca = Adapter.create(pc)
 
-        reference_adapter = Adapter.create(r)
+    cw_obj = pca.get_cw()
+    pow_obj = pca.get_pow()
 
-        experiment = reference_adapter.get_pow()
-        reference = reference_adapter.get_cw()
+    PyOpenWorm.connect()
 
-        PyOpenWorm.connect()
+    pow_dict = {
+        'delta_t': pow_obj.delta_t(),
+        'duration': pow_obj.duration(),
+        'end_time': pow_obj.end_time(),
+        'ion_channel': pow_obj.ion_channel(),
+        'protocol_end': pow_obj.protocol_end(),
+        'protocol_start': pow_obj.protocol_start(),
+        'protocol_step': pow_obj.protocol_step(),
+        'start_time': pow_obj.start_time(),
+    }
 
-        pyow_dict = {
-            'authors': experiment.author(),
-            'doi': experiment.doi(),
-            'pmid': experiment.pmid(),
-            'title': experiment.title(),
-            'url': experiment.uri(),
-            'year': experiment.year(),
-        }
+    cw_dict = {
+        'delta_t': cw_obj.deltat,
+        'duration': cw_obj.duration,
+        'end_time': cw_obj.end_time,
+        'ion_channel': cw_obj.ion_channel,
+        'protocol_end': cw_obj.protocol_end,
+        'protocol_start': cw_obj.protocol_start,
+        'protocol_step': cw_obj.protocol_step,
+        'start_time': cw_obj.start_time,
+    }
 
-        cw_dict = {
-            'authors': set([reference.authors]),
-            'doi': reference.doi,
-            'pmid': reference.PMID,
-            'title': reference.title,
-            'url': set([reference.url]),
-            'year': reference.year
-        }
+    PyOpenWorm.disconnect()
 
-        PyOpenWorm.disconnect()
+    assert cw_dict == pow_dict
 
-        assert pyow_dict == cw_dict
+def test_create_ion_channel(data_pool):
+    """
+    Can we create an IonChannel manually?
+    """
+    ic = data_pool.get_ion_channel()
+    assert isinstance(ic, IonChannel)
 
-    def test_create_PatchClamp(self):
-        """Test that we can create a PatchClamp object manually."""
-        pc = self.get_patch_clamp()
-        assert isinstance(pc, PatchClamp)
+@pytest.mark.xfail
+def test_adapt_IonChannel(data_pool):
+    """
+    Test that we can map a IonChannel object to a PyOpenWorm
+    Channel object.
+    """
+    ic = data_pool.get_ion_channel()
+    ica = Adapter.create(ic)
 
-    def test_adapt_PatchClamp(self):
-        """
-        Test that we can map a PatchClamp object to a PyOpenWorm
-        PatchClamp object.
-        """
-        pc = self.get_patch_clamp()
+    cw_obj = ica.get_cw()
+    pow_obj = ica.get_pow()
 
-        pca = Adapter.create(pc)
+    # parse PMIDs for expression_patterns,
+    # then for descriptions
+    # and finally proteins
+    exp_strings = cw_obj.expression_evidences.split(', ')
+    cw_expression_pmids = set(int(s) for s in exp_strings)
 
-        cw_obj = pca.get_cw()
-        pow_obj = pca.get_pow()
+    desc_strings = cw_obj.description_evidences.split(', ')
+    cw_description_pmids = set(int(s) for s in desc_strings)
 
-        PyOpenWorm.connect()
+    cw_proteins = set(cw_obj.proteins.split('; '))
 
-        pow_dict = {
-            'delta_t': pow_obj.delta_t(),
-            'duration': pow_obj.duration(),
-            'end_time': pow_obj.end_time(),
-            'ion_channel': pow_obj.ion_channel(),
-            'protocol_end': pow_obj.protocol_end(),
-            'protocol_start': pow_obj.protocol_start(),
-            'protocol_step': pow_obj.protocol_step(),
-            'start_time': pow_obj.start_time(),
-        }
+    cw_dict = {
+        'channel_name': cw_obj.channel_name,
+        'description': cw_obj.description,
+        'description_evidences': cw_obj.description_evidences,
+        'gene_name': cw_obj.gene_name,
+        'gene_WB_ID': cw_obj.gene_WB_ID,
+        'gene_class': cw_obj.gene_class,
+        'proteins': cw_proteins,
+        'expression_pattern': cw_obj.expression_pattern,
+        'expression_evidences': cw_obj.expression_evidences,
+    }
 
-        cw_dict = {
-            'delta_t': cw_obj.deltat,
-            'duration': cw_obj.duration,
-            'end_time': cw_obj.end_time,
-            'ion_channel': cw_obj.ion_channel,
-            'protocol_end': cw_obj.protocol_end,
-            'protocol_start': cw_obj.protocol_start,
-            'protocol_step': cw_obj.protocol_step,
-            'start_time': cw_obj.start_time,
-        }
+    # retrieve PMIDs for expression_patterns,
+    # then for descriptions
+    ev = PyOpenWorm.Evidence()
+    ev.asserts(pow_obj.expression_pattern)
+    pow_expression_pmids = set(e.pmid() for e in ev.load())
 
-        PyOpenWorm.disconnect()
+    ev = PyOpenWorm.Evidence()
+    ev.asserts(pow_obj.description)
+    pow_description_pmids = set(e.pmid() for e in ev.load())
 
-        assert cw_dict == pow_dict
+    pow_dict = {
+        'channel_name': pow_obj.name(),
+        'description': pow_obj.description(),
+        'description_evidences': pow_description_pmids,
+        'gene_name': pow_obj.gene_name(),
+        'gene_WB_ID': pow_obj.gene_WB_ID(),
+        'gene_class': pow_obj.gene_class(),
+        'proteins': pow_obj.proteins(),
+        'expression_pattern': pow_obj.expression_pattern(),
+        'expression_evidences': pow_expression_pmids,
+    }
 
-    def test_create_ion_channel(self):
-        """
-        Can we create an IonChannel manually?
-        """
-        ic = self.get_ion_channel()
-        assert isinstance(ic, IonChannel)
+    assert pow_dict == cw_dict
 
-    @unittest.expectedFailure
-    def test_adapt_IonChannel(self):
-        """
-        Test that we can map a IonChannel object to a PyOpenWorm
-        Channel object.
-        """
-        ic = self.get_ion_channel()
-        ica = Adapter.create(ic)
-
-        cw_obj = ica.get_cw()
-        pow_obj = ica.get_pow()
-
-        # parse PMIDs for expression_patterns,
-        # then for descriptions
-        # and finally proteins
-        exp_strings = cw_obj.expression_evidences.split(', ')
-        cw_expression_pmids = set(int(s) for s in exp_strings)
-
-        desc_strings = cw_obj.description_evidences.split(', ')
-        cw_description_pmids = set(int(s) for s in desc_strings)
-
-        cw_proteins = set(cw_obj.proteins.split('; '))
-
-        cw_dict = {
-            'channel_name': cw_obj.channel_name,
-            'description': cw_obj.description,
-            'description_evidences': cw_obj.description_evidences,
-            'gene_name': cw_obj.gene_name,
-            'gene_WB_ID': cw_obj.gene_WB_ID,
-            'gene_class': cw_obj.gene_class,
-            'proteins': cw_proteins,
-            'expression_pattern': cw_obj.expression_pattern,
-            'expression_evidences': cw_obj.expression_evidences,
-        }
-
-        # retrieve PMIDs for expression_patterns,
-        # then for descriptions
-        ev = PyOpenWorm.Evidence()
-        ev.asserts(pow_obj.expression_pattern)
-        pow_expression_pmids = set(e.pmid() for e in ev.load())
-
-        ev = PyOpenWorm.Evidence()
-        ev.asserts(pow_obj.description)
-        pow_description_pmids = set(e.pmid() for e in ev.load())
-
-        pow_dict = {
-            'channel_name': pow_obj.name(),
-            'description': pow_obj.description(),
-            'description_evidences': pow_description_pmids,
-            'gene_name': pow_obj.gene_name(),
-            'gene_WB_ID': pow_obj.gene_WB_ID(),
-            'gene_class': pow_obj.gene_class(),
-            'proteins': pow_obj.proteins(),
-            'expression_pattern': pow_obj.expression_pattern(),
-            'expression_evidences': pow_expression_pmids,
-        }
-
-        self.assertEqual( pow_dict , cw_dict)

--- a/tests/adapter_test.py
+++ b/tests/adapter_test.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 from django.utils import timezone
-from ion_channel import adapters
+from ion_channel.adapters import Adapter
 import PyOpenWorm, pytest, unittest, random
 from ion_channel.models import *
 
@@ -95,7 +95,7 @@ class AdapterTestCase(TestCase):
         Experiment object."""
         r = self.get_reference()
 
-        reference_adapter = adapters.ReferenceAdapter(r)
+        reference_adapter = Adapter.create(r)
 
         experiment = reference_adapter.get_pow()
         reference = reference_adapter.get_cw()
@@ -136,7 +136,7 @@ class AdapterTestCase(TestCase):
         """
         pc = self.get_patch_clamp()
 
-        pca = adapters.PatchClampAdapter(pc)
+        pca = Adapter.create(pc)
 
         cw_obj = pca.get_cw()
         pow_obj = pca.get_pow()
@@ -183,7 +183,7 @@ class AdapterTestCase(TestCase):
         Channel object.
         """
         ic = self.get_ion_channel()
-        ica = adapters.IonChannelAdapter(ic)
+        ica = Adapter.create(ic)
 
         cw_obj = ica.get_cw()
         pow_obj = ica.get_pow()

--- a/tests/adapter_test.py
+++ b/tests/adapter_test.py
@@ -1,9 +1,9 @@
-import PyOpenWorm, pytest, unittest, random
-from django.test import TestCase
+import PyOpenWorm, pytest, unittest
 from ion_channel.adapters import Adapter
 from ion_channel.models import (
     IonChannel, Reference, Experiment, PatchClamp, User
 )
+
 
 pytestmark = [pytest.mark.django_db]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,92 @@
+import pytest
+from django.utils import timezone
+from ion_channel.models import (
+    IonChannel, Reference, Experiment, PatchClamp, User
+)
+
+
+@pytest.fixture(scope='session')
+def data_pool():
+    return DataPool()
+
+class DataPool(object):
+    def get_user(self):
+        """
+        Fixture for getting a User object.
+        If we already created one, we can just get it
+        rather than making another.
+        """
+        if not hasattr(self, 'user'):
+            self.user = User.objects.create(username='user')
+
+        return self.user
+
+    def get_reference(self):
+        """
+        Fixture for getting a Reference object.
+        """
+        if not hasattr(self, 'reference'):
+            self.reference = Reference.objects.create(
+                PMID='000000',
+                authors='Einstein et al.',
+                create_date=timezone.now(),
+                doi='123abc',
+                title='Hello Worm',
+                url='http://example.co.uk',
+                username=self.get_user(),
+                year=2001,
+            )
+
+        return self.reference
+
+    def get_experiment(self):
+        """
+        Fixture for getting an Experiment object.
+        """
+        if not hasattr(self, 'experiment'):
+            self.experiment = Experiment.objects.create(
+                reference=self.get_reference(),
+                username=self.get_user(),
+                create_date=timezone.now(),
+            )
+
+        return self.experiment
+
+    def get_ion_channel(self):
+        """
+        Fixture for getting an IonChannel object.
+        """
+        if not hasattr(self, 'ion_channel'):
+            self.ion_channel = IonChannel.objects.create(
+                channel_name='CNN',
+                description='Yup, it is a channel.',
+                description_evidences='0000000, 000001',
+                gene_name='Gene Clark',
+                gene_WB_ID='Wbbt:123456',
+                gene_class='Working Class',
+                proteins='BRD-5, isoform a; BRD-5, isoform b',
+                expression_pattern='Have you seen the Silver Raven?',
+                expression_evidences='000000, 000002',
+            )
+
+        return self.ion_channel
+
+    def get_patch_clamp(self):
+        """
+        Fixture for getting a PatchClamp object.
+        """
+        if not hasattr(self, 'patch_clamp'):
+            self.patch_clamp = PatchClamp.objects.create(
+                deltat=100,
+                duration=200,
+                end_time=200,
+                experiment=self.get_experiment(),
+                ion_channel=self.get_ion_channel(),
+                protocol_end=200,
+                protocol_start=0,
+                protocol_step=100,
+                start_time=0,
+            )
+
+        return self.patch_clamp
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,13 @@ def data_pool():
     return DataPool()
 
 class DataPool(object):
+    """
+    Session-level pytest fixture (see 'data_pool()' above)
+    which can create a data object of several types, or return
+    one if it has been created previously.
+
+    Implementation of the 'Object Pool' design pattern.
+    """
     def get_user(self):
         """
         Fixture for getting a User object.

--- a/tests/export_test.py
+++ b/tests/export_test.py
@@ -1,28 +1,70 @@
-import pytest
-import ion_channel.models as models
-from django.test import TestCase
-from ion_channel.adapters import Adapter
+import os, pytest, rdflib, tempfile
 from ion_channel.exporter import Exporter
 
 
-class ExporterTestCase(TestCase):
+pytestmark = [pytest.mark.django_db]
 
-    def test_init_exporter(self):
-        """
-        Can we create an Exporter with arguments?
-        Uses IonChannel and Experiment as example data.
-        """
-        ic = atc.get_ion_channel()
-        ex = atc.get_experiment()
-        expo = Exporter(ic, ex)
-        assert type(expo) == Exporter
+SAMPLE_LOCATION = os.path.join('tests', 'test_data', 'rdf_data.n3')
+EXPORT_LOCATION = os.path.join('tests', 'test_data', 'exported_data.n3')
 
-    def test_load_type_error(self):
-        """
-        Do we get the correct exception if we try to load 
-        non-Model data into the Exporter?
-        """
-        with pytest.raises(TypeError):
-            Exporter(None)
+def test_exporter_init_and_load(data_pool):
+    """
+    Can we create an Exporter with arguments?
+    Uses IonChannel and Experiment as example data.
+    Implicitly tests Exporter's load() method.
+    """
+    ic = data_pool.get_ion_channel()
+    ex = data_pool.get_experiment()
+    expo = Exporter(ic, ex)
+    assert type(expo) == Exporter
 
+def test_load_type_error():
+    """
+    Do we get the correct exception if we try to load 
+    non-Model data into the Exporter?
+    """
+    with pytest.raises(TypeError):
+        Exporter(None)
+
+def test_parse_without_source():
+    """
+    When we try to parse without a 'source' argument, do
+    we get the correct error type?
+    """
+    expo = Exporter()
+    with pytest.raises(TypeError):
+        expo.parse(source=None)
+
+def test_parse():
+    """
+    Can the parse() method actually parse an RDF graph?
+    After parsing, is the graph identical to what RDFLib
+    parses?
+    """
+    expo = Exporter()
+    expo.parse(source=SAMPLE_LOCATION)
+
+    graph = rdflib.Graph()
+    graph.parse(source=SAMPLE_LOCATION, format='n3')
+
+    assert graph.isomorphic(expo.graph)
+
+def test_load_parse_and_export(data_pool):
+    """
+    Can we load and parse data, then export it?
+    Test passes if we can load, parse and export without
+    error, and the resulting graph is the same as one
+    previously created with RDFLib.
+    """
+    fname = tempfile.mktemp()
+    expo = Exporter()
+    ic = data_pool.get_ion_channel()
+    expo.parse(SAMPLE_LOCATION)
+    expo.load(ic)
+    expo.export(filename=fname)
+
+    current_graph = rdflib.Graph().parse(fname, format='n3')
+    known_graph = rdflib.Graph().parse(EXPORT_LOCATION, format='n3')
+
+    assert current_graph.isomorphic(known_graph)
 

--- a/tests/export_test.py
+++ b/tests/export_test.py
@@ -1,0 +1,28 @@
+import pytest
+import ion_channel.models as models
+from django.test import TestCase
+from ion_channel.adapters import Adapter
+from ion_channel.exporter import Exporter
+
+
+class ExporterTestCase(TestCase):
+
+    def test_init_exporter(self):
+        """
+        Can we create an Exporter with arguments?
+        Uses IonChannel and Experiment as example data.
+        """
+        ic = atc.get_ion_channel()
+        ex = atc.get_experiment()
+        expo = Exporter(ic, ex)
+        assert type(expo) == Exporter
+
+    def test_load_type_error(self):
+        """
+        Do we get the correct exception if we try to load 
+        non-Model data into the Exporter?
+        """
+        with pytest.raises(TypeError):
+            Exporter(None)
+
+

--- a/tests/test_data/exported_data.n3
+++ b/tests/test_data/exported_data.n3
@@ -1,0 +1,34 @@
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ns1: <http://openworm.org/entities/Channel/> .
+@prefix ns2: <http://openworm.org/entities/SimpleProperty/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://example.org/people/Bob> a foaf:Person ;
+    foaf:knows [ a foaf:Person ;
+            foaf:name "Linda" ] ;
+    foaf:name "Bob" .
+
+ns1:a2435a45b85628172c5a47122144a7c67 a <http://openworm.org/entities/Channel> ;
+    ns1:description <http://openworm.org/entities/Channel_description/a45d3682f613511cb7f5933cc596bb8c8> ;
+    ns1:expression_pattern <http://openworm.org/entities/Channel_expression_pattern/a8423ea724f2948e6f68f617b93c90e3e> ;
+    ns1:gene_WB_ID <http://openworm.org/entities/Channel_gene_WB_ID/a9574ce1471c7cb83f203c8b76c44078b> ;
+    ns1:gene_name <http://openworm.org/entities/Channel_gene_name/ac2a817e5c7dab1c5b791063fa24e9fb6> ;
+    ns1:name <http://openworm.org/entities/Channel_name/a0bed6d9a5ab8d508f3cbeacc102505f9> ;
+    ns1:proteins <http://openworm.org/entities/Channel_proteins/a879f3dc76a85c7a9eb01bc834ae7b740> .
+
+<http://openworm.org/entities/Channel_description/a45d3682f613511cb7f5933cc596bb8c8> ns2:value "Yup, it is a channel." .
+
+<http://openworm.org/entities/Channel_expression_pattern/a8423ea724f2948e6f68f617b93c90e3e> ns2:value "Have you seen the Silver Raven?" .
+
+<http://openworm.org/entities/Channel_gene_WB_ID/a9574ce1471c7cb83f203c8b76c44078b> ns2:value "Wbbt:123456" .
+
+<http://openworm.org/entities/Channel_gene_name/ac2a817e5c7dab1c5b791063fa24e9fb6> ns2:value "Gene Clark" .
+
+<http://openworm.org/entities/Channel_name/a0bed6d9a5ab8d508f3cbeacc102505f9> ns2:value "CNN" .
+
+<http://openworm.org/entities/Channel_proteins/a879f3dc76a85c7a9eb01bc834ae7b740> ns2:value "BRD-5, isoform a",
+        "BRD-5, isoform b" .
+

--- a/tests/test_data/rdf_data.n3
+++ b/tests/test_data/rdf_data.n3
@@ -1,0 +1,9 @@
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+<http://example.org/people/Bob>
+  a foaf:Person ;
+  foaf:knows [
+    a foaf:Person ;
+    foaf:name "Linda"
+  ] ;
+  foaf:name "Bob" .


### PR DESCRIPTION
Adds `Exporter` class, which enables us to export ChannelWorm objects to a form consumable by PyOpenWorm.

The `Exporter` can load ChannelWorm objects, parse previous RDF graphs, and export to RDF formats.

Also adds tests for all of this.