### PR TITLE
fix string denotation in channel worm

### DIFF
--- a/channelworm/ion_channel/models.py
+++ b/channelworm/ion_channel/models.py
@@ -146,7 +146,7 @@ class CellChannel(models.Model):
     reference = models.ForeignKey(Reference)
 
     def __unicode__(self):
-        return `self.cell` + ", " + `self.ion_channel`
+        return "self.cell" + ", " + "self.ion_channel"
 
 
 # TODO: Separate experiment conditions from patch clamp
@@ -198,7 +198,7 @@ class PatchClamp(models.Model):
     pipette_solution = models.TextField(blank=True, null=True, verbose_name='Pipette Solution (e.g. 120e-3 KCl, 20e-3 KOH,...)')
 
     def __unicode__(self):
-        return `self.ion_channel` + " " + `self.experiment` + " " + self.type
+        return "self.ion_channel" + " " + "self.experiment" + " " + self.type
 
 
 # TODO: consider multiple channels
@@ -285,7 +285,7 @@ class IonChannelModel(models.Model):
     references = models.ManyToManyField(Reference)
 
     def __unicode__(self):
-        return `self.channel_name` + " " + `self.experiment`
+        return "self.channel_name" + " " + "self.experiment"
 
 class Protein(models.Model):
     name = models.CharField(max_length=300, unique=True)


### PR DESCRIPTION
Hi there is some strange string notation that uses ` ` to signify what I assume is a string data type. Anyway I think I have fixed it. 