### PR TITLE
Revised README & empty submodule fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Also, take a look at the comments in *requirements.txt* for some requirements th
 * **Ion channel modeling**
   * Build Hodgkin-Huxley models for ion channels based on experimental patch clamp studies
   * Estimate kinetics and build models for ion channels with no patch clamp data available (based on homologous channel types)
-  * Create verification & validation tests to prove matching of the models with experimental data
+  * Create tests to validate models with respect to experimental data
 * **Setting up a simulation environment**
   * Simulate the computational analysis phase of a patch clamp experiment
   * Simulate and run customized versions of ion channel(s) in cell(s)
@@ -38,7 +38,8 @@ Also, take a look at the comments in *requirements.txt* for some requirements th
 ## Relationship to PyOpenWorm and other sub-projects
 Simulating *C. elegans* requires curating multiple types of static data and physiological models
 pertaining to the biology of the worm.  Ion channels are simply one type of model.
-Others types include muscular movement, the structure of the nervous system itself (i.e. connectome),
+Others types include models of muscular movement, data pertaining to the structure
+of the nervous system itself (i.e. connectome),
 and in the future, models of development and reproduction.  
 
 PyOpenWorm is intended to be an integrated and unified data access layer for

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # ChannelWorm
- 
+
 [![Documentations](https://readthedocs.org/projects/channelworm/badge/?version=latest)](http://channelworm.readthedocs.org/en/latest/) [![Join the chat at https://gitter.im/VahidGh/ChannelWorm](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/openworm/ChannelWorm?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![Stories in Ready](https://badge.waffle.io/vahidgh/channelworm.png?label=ready&title=Ready)](https://waffle.io/vahidgh/channelworm) [![Build Status](https://travis-ci.org/openworm/ChannelWorm.svg?branch=dev)](https://travis-ci.org/openworm/ChannelWorm)
 
-The aim of the **ChannelWorm** is to integrate information and tools related to modeling ion channels in C. elegans for the [OpenWorm Project](https://github.com/openworm).
+The aim of the **ChannelWorm** project is to integrate information and tools related to
+modeling ion channels in *C. elegans* for the [OpenWorm Project](https://github.com/openworm).
 
 ## Installation
 
@@ -11,7 +12,7 @@ Also, take a look at the comments in *requirements.txt* for some requirements th
 
 ## Objectives
 * **Information Management**
-  * Integrate and structure data related to ion channels in C. elegans, from genotype to phenotype
+  * Integrate and structure data related to ion channels in *C. elegans*, from genotype to phenotype
   * Develop APIs for accessing data
   * Keep data up-to-date
 * **Ion channel modeling**
@@ -24,15 +25,30 @@ Also, take a look at the comments in *requirements.txt* for some requirements th
   * Check if the simulation fits the biological boundaries
 
 ## Some use cases
-  * I want to know which type of ion channels we have in C. elegans!
+  * I want to know which type of ion channels we have in *C. elegans*!
   * I want to know in which cell which gene encodes which protein/subtype of which ion channel!
   * I want to view, build, or validate a model of an ion channel
   * I want to check references that data or models are based on
   * I have some graphs/data from a patch clamp experiment and want to build a HH model
   * I want to have a customized version of an ion channel model (e.g. of a mutant)
   * I want to run my customized model of ion channel(s) (along with other ion channels) in a simulation environment
-  * I want to simulate a patch clamp experiment with known mutations in genes encoding ion channels in C. elegans
-  * I want to simulate ion channel diseases (channelopathies), and investigate defects in neuromuscular transmission, C. elegans movement, etc.
+  * I want to simulate a patch clamp experiment with known mutations in genes encoding ion channels in *C. elegans*
+  * I want to simulate ion channel diseases (channelopathies), and investigate defects in neuromuscular transmission, *C. elegans* movement, etc.
+
+## Relationship to PyOpenWorm and other sub-projects
+Simulating *C. elegans* requires curating multiple types of static data and physiological models
+pertaining to the biology of the worm.  Ion channels are simply one type of model.
+Others types include muscular movement, the structure of the nervous system itself (i.e. connectome),
+and in the future, models of development and reproduction.  
+
+PyOpenWorm is intended to be an integrated and unified data access layer for
+the diverse sub-projects of OpenWorm which house physiological data and dynamic models.
+ChannelWorm is one such "consumer" of PyOpenWorm.  However, because these
+projects were developed somewhat independently, some amount of physiological
+information is itself housed in the PyOpenWorm repository.  Ultimately, the
+purely functional core of PyOpenWorm will be separated out and the data
+appropriately distributed across other sub-projects. See the [PyOpenWorm](https://github.com/openworm/PyOpenWorm)
+README for more information.   
 
 ## Implementation
 As part of the OpenWorm's Muscle-Neuron-Channel [integration plan](http://docs.openworm.org/en/latest/Projects/muscle-neuron-integration/), ChannelWorm is developing based on the following components:
@@ -43,5 +59,3 @@ As part of the OpenWorm's Muscle-Neuron-Channel [integration plan](http://docs.o
    * Using the [Test suite](https://github.com/openworm/ChannelWorm/tree/master/tests), verification tests are applied, and models validating by [SciUnit](https://github.com/scidash/sciunit) testing framework.
    * Final models are generated in [NeuroML2](https://github.com/NeuroML) format, in addition to [LEMS](https://github.com/LEMS) files for simulation environments.
    * Verified models and simulations can be run in the [Geppetto](https://github.com/openworm/org.geppetto) simulation platform.
- 
-

--- a/README.md
+++ b/README.md
@@ -52,9 +52,10 @@ appropriately distributed across other sub-projects. See the [PyOpenWorm](https:
 README for more information.   
 
 ## Implementation
-As part of the OpenWorm's Muscle-Neuron-Channel [integration plan](http://docs.openworm.org/en/latest/Projects/muscle-neuron-integration/), ChannelWorm is developing based on the following components:
+As part of OpenWorm's Muscle-Neuron-Channel [integration plan](http://docs.openworm.org/en/latest/Projects/muscle-neuron-integration/), development
+of ChannelWorm is build around the following components:
 
-   * The [PyOpenWorm](https://github.com/openworm/PyOpenWorm) is the main data layer API for the knowledge base.
+   * [PyOpenWorm](https://github.com/openworm/PyOpenWorm) is the main data layer API for the knowledge base.
    * The [Django app](http://channelwormdjango-channelworm.rhcloud.com/) is being used as an interface for digitization, data representation and user interaction.
    * Collected data fits to dynamic models using [cwFitter](https://github.com/openworm/ChannelWorm/tree/master/channelworm/fitter) optimization engine.
    * Using the [Test suite](https://github.com/openworm/ChannelWorm/tree/master/tests), verification tests are applied, and models validating by [SciUnit](https://github.com/scidash/sciunit) testing framework.


### PR DESCRIPTION
1) Small updates to parallel some changes with PyOW README
2) Fix for an empty submodule error message when pulling from the base fork